### PR TITLE
Support explicit cluster bus port

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -95,7 +95,8 @@ typedef struct clusterNode {
     mstime_t repl_offset_time;  /* Unix time we received offset for this node */
     long long repl_offset;      /* Last known repl offset for this node. */
     char ip[REDIS_IP_STR_LEN];  /* Latest known IP address of this node */
-    int port;                   /* Latest known port of this node */
+    uint16_t port;              /* Latest known service port of this node */
+    uint16_t cluster_port;      /* Latest known cluster port of this node */
     clusterLink *link;          /* TCP/IP link with this node */
     list *fail_reports;         /* List of nodes signaling this as failing */
 } clusterNode;
@@ -168,8 +169,8 @@ typedef struct {
     char ip[REDIS_IP_STR_LEN];  /* IP address last time it was seen */
     uint16_t port;              /* port last time it was seen */
     uint16_t flags;             /* node->flags copy */
-    uint16_t notused1;          /* Some room for future improvements. */
-    uint32_t notused2;
+    uint16_t cluster_port;      /* cluster port last time it was seen. */
+    uint32_t notused1;          /* Some room for future improvements. */
 } clusterMsgDataGossip;
 
 typedef struct {
@@ -233,7 +234,7 @@ typedef struct {
     unsigned char myslots[REDIS_CLUSTER_SLOTS/8];
     char slaveof[REDIS_CLUSTER_NAMELEN];
     char notused1[32];  /* 32 bytes reserved for future usage. */
-    uint16_t port;      /* Sender TCP base port */
+    uint16_t port;      /* Sender TCP service port */
     uint16_t flags;     /* Sender node flags */
     unsigned char state; /* Cluster state from the POV of the sender */
     unsigned char mflags[3]; /* Message flags: CLUSTERMSG_FLAG[012]_... */

--- a/src/redis.c
+++ b/src/redis.c
@@ -1479,6 +1479,7 @@ void initServerConfig(void) {
     server.repl_min_slaves_to_write = REDIS_DEFAULT_MIN_SLAVES_TO_WRITE;
     server.repl_min_slaves_max_lag = REDIS_DEFAULT_MIN_SLAVES_MAX_LAG;
     server.cluster_enabled = 0;
+    server.cluster_port = 0;
     server.cluster_node_timeout = REDIS_CLUSTER_DEFAULT_NODE_TIMEOUT;
     server.cluster_migration_barrier = REDIS_CLUSTER_DEFAULT_MIGRATION_BARRIER;
     server.cluster_slave_validity_factor = REDIS_CLUSTER_DEFAULT_SLAVE_VALIDITY;

--- a/src/redis.h
+++ b/src/redis.h
@@ -894,6 +894,7 @@ struct redisServer {
                                    xor of REDIS_NOTIFY... flags. */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
+    int cluster_port;           /* TCP listening port for cluster operations */
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
     struct clusterState *cluster;  /* State of the cluster */


### PR DESCRIPTION
Support an explicit cluster bus port in addition to the implicit cluster
bus port (of service port + 10000), including upgrade path to using this
feature. Specifically:
- Add configuration option, cluster-port, for specifying cluster port
- Add optional cluster port to MEET command (if omitted, assume implicit
  port is used by the host being met).
- Add optional cluster port to persisted nodes.conf and response to
  CLUSTER NODES command (omitted if the cluster bus port, whether
  explicit or implicit, is equal to the implicit cluster port).

If the implicit port is used (even if expressed explicitly), the API
remains unchanged (nodes.conf and the response to CLUSTER NODES will be
the same), allowing existing clients (that don't support the additional
port) to continue to function.

A cluster may comprise a mix of both nodes that support an explicit port
and those that don't, provided the explicit port feature is not used.
This allows for an in-place upgrade path from a cluster without support
to a cluster that uses an explicit port.
